### PR TITLE
Raise Exception when connection fails

### DIFF
--- a/groupme_push/client.py
+++ b/groupme_push/client.py
@@ -66,7 +66,7 @@ class PushClient:
         except Exception as e:
                 logger.error("Unhandled exception:")
                 logger.error(e, exc_info=True)
-                raise Exception("Failed to connect to GroupMe")
+                raise
 
             
 

--- a/groupme_push/client.py
+++ b/groupme_push/client.py
@@ -3,7 +3,6 @@ from threading import Thread
 import time
 import json
 import logging
-from queue import Queue
 
 
 logger = logging.getLogger("groupme-push")

--- a/groupme_push/client.py
+++ b/groupme_push/client.py
@@ -3,6 +3,8 @@ from threading import Thread
 import time
 import json
 import logging
+from queue import Queue
+
 
 logger = logging.getLogger("groupme-push")
 
@@ -21,7 +23,6 @@ class PushClient:
         on_other=None,
         disregard_self=False,
         reconnect=None,
-        exception_callback=None
     ):
         self.id = 1
         self.access_token = access_token
@@ -31,8 +32,7 @@ class PushClient:
         self.favorite_callback = on_favorite
         self.other_callback = on_other
         self.disregard_self = disregard_self
-        self.reconnect=None
-        self.exception_callback = exception_callback
+        self.reconnect = reconnect
     
 
     def start(self):
@@ -65,12 +65,10 @@ class PushClient:
             self.thread = Thread(target=self.run_forever)
             self.thread.start()
         except Exception as e:
-            if self.exception_callback:
-                self.exception_callback(e)
-            else:
                 logger.error("Unhandled exception:")
                 logger.error(e, exc_info=True)
-                
+                raise Exception("Failed to connect to GroupMe")
+
             
 
     def stop(self):


### PR DESCRIPTION
Remove exception_callback option. Never was really needed. Instead we throw the exception so users can catch exceptions using try/except. 

fix a mistake in reconnect. Instead of defining it as None, define it as the user definiton (oops...)

